### PR TITLE
Fix: auction scaling

### DIFF
--- a/src/AtmAuction.sol
+++ b/src/AtmAuction.sol
@@ -4,14 +4,18 @@ pragma solidity ^0.8.13;
 import {DutchAuction} from "./DutchAuction.sol";
 import {SafeTransferLib} from "solady/src/utils/SafeTransferLib.sol";
 import {IEthStrategy} from "./DutchAuction.sol";
-
+import {console} from "forge-std/console.sol";
 contract AtmAuction is DutchAuction {
 
     constructor(address _ethStrategy, address _governor, address _paymentToken) DutchAuction(_ethStrategy, _governor, _paymentToken) {}
 
     function _fill(uint128 amount, uint128 price, uint64 startTime, uint64 duration) internal override {
       super._fill(amount, price, startTime, duration);
-      SafeTransferLib.safeTransferFrom(paymentToken, msg.sender, owner(), amount * price);
+      uint256 amountToTransfer = amount * price / 10**decimals;
+      console.log("amountToTransfer", amountToTransfer);
+      console.log("decimals", decimals);
+      console.log("amount", amount);
+      SafeTransferLib.safeTransferFrom(paymentToken, msg.sender, owner(), amountToTransfer);
       IEthStrategy(ethStrategy).mint(msg.sender, amount);
     }
 }

--- a/src/AtmAuction.sol
+++ b/src/AtmAuction.sol
@@ -4,18 +4,13 @@ pragma solidity ^0.8.13;
 import {DutchAuction} from "./DutchAuction.sol";
 import {SafeTransferLib} from "solady/src/utils/SafeTransferLib.sol";
 import {IEthStrategy} from "./DutchAuction.sol";
-import {console} from "forge-std/console.sol";
 contract AtmAuction is DutchAuction {
 
     constructor(address _ethStrategy, address _governor, address _paymentToken) DutchAuction(_ethStrategy, _governor, _paymentToken) {}
 
     function _fill(uint128 amount, uint128 price, uint64 startTime, uint64 duration) internal override {
       super._fill(amount, price, startTime, duration);
-      uint256 amountToTransfer = amount * price / 10**decimals;
-      console.log("amountToTransfer", amountToTransfer);
-      console.log("decimals", decimals);
-      console.log("amount", amount);
-      SafeTransferLib.safeTransferFrom(paymentToken, msg.sender, owner(), amountToTransfer);
+      SafeTransferLib.safeTransferFrom(paymentToken, msg.sender, owner(), amount * price / 10**decimals);
       IEthStrategy(ethStrategy).mint(msg.sender, amount);
     }
 }

--- a/src/BondAuction.sol
+++ b/src/BondAuction.sol
@@ -27,7 +27,7 @@ contract BondAuction is DutchAuction {
         if(bonds[msg.sender].startRedemption != 0) {
           revert UnredeemedBond();
         }
-        SafeTransferLib.safeTransferFrom(paymentToken, msg.sender, address(this), amount * price);
+        SafeTransferLib.safeTransferFrom(paymentToken, msg.sender, address(this), amount * price / 10**decimals);
         bonds[msg.sender] = Bond({
           amount: amount,
           price: price,
@@ -52,7 +52,7 @@ contract BondAuction is DutchAuction {
         revert RedemptionWindowPassed();
       }
       delete bonds[msg.sender];
-      SafeTransferLib.safeTransfer(paymentToken, owner(), bond.amount * bond.price);
+      SafeTransferLib.safeTransfer(paymentToken, owner(), bond.amount * bond.price / 10**decimals);
       IEthStrategy(ethStrategy).mint(msg.sender, bond.amount);
     }
 
@@ -69,7 +69,7 @@ contract BondAuction is DutchAuction {
       if(currentTime < bond.startRedemption) {
         revert RedemptionWindowNotStarted();
       }
-      SafeTransferLib.safeTransfer(paymentToken, msg.sender, bond.amount * bond.price);
+      SafeTransferLib.safeTransfer(paymentToken, msg.sender, bond.amount * bond.price / 10**decimals);
       delete bonds[msg.sender];
     }
 }

--- a/test/AtmAuction.t.sol
+++ b/test/AtmAuction.t.sol
@@ -32,21 +32,21 @@ contract AtmAuctionTest is DutchAuctionTest {
   }
 
   function test_fill_success_1() public override {
-    mintAndApprove(alice, defaultAmount * defaultStartPrice, address(dutchAuction), address(usdcToken));
+    mintAndApprove(alice, defaultAmount * defaultStartPrice / 1e18, address(dutchAuction), address(usdcToken));
     super.test_fill_success_1();
 
     assertEq(usdcToken.balanceOf(alice), 0, "usdcToken balance not assigned correctly");
-    assertEq(usdcToken.balanceOf(address(governor)), defaultAmount * defaultStartPrice, "usdcToken balance not assigned correctly");
+    assertEq(usdcToken.balanceOf(address(governor)), defaultAmount * defaultStartPrice / 1e18, "usdcToken balance not assigned correctly");
     assertEq(ethStrategy.balanceOf(alice), defaultAmount, "ethStrategy balance not assigned correctly");
   }
 
   function test_fill_success_2() public override {
     uint256 _amount = defaultAmount - 1;
-    mintAndApprove(alice, _amount * defaultStartPrice, address(dutchAuction), address(usdcToken));
+    mintAndApprove(alice, _amount * defaultStartPrice/1e18, address(dutchAuction), address(usdcToken));
     super.test_fill_success_2();
 
     assertEq(usdcToken.balanceOf(alice), 0, "usdcToken balance not assigned correctly");
-    assertEq(usdcToken.balanceOf(address(governor)), _amount * defaultStartPrice, "usdcToken balance not assigned correctly");
+    assertEq(usdcToken.balanceOf(address(governor)), _amount * defaultStartPrice / 1e18, "usdcToken balance not assigned correctly");
     assertEq(ethStrategy.balanceOf(alice), _amount, "ethStrategy balance not assigned correctly");
   }
 
@@ -71,7 +71,7 @@ contract AtmAuctionTest is DutchAuctionTest {
     vm.assume(delta_t <= type(uint128).max / delta_p);
 
     uint128 fillPrice = calculateFillPrice(_startTime, _duration, _startPrice, _endPrice, _elapsedTime);
-    uint256 mintAmount = _amount * fillPrice;
+    uint256 mintAmount = _amount * fillPrice / 1e18;
     mintAndApprove(alice, mintAmount, address(dutchAuction), address(usdcToken));
 
     fill(_amount, _startTime, _duration, _startPrice, _endPrice, _elapsedTime, _totalAmount);

--- a/test/AtmAuction.t.sol
+++ b/test/AtmAuction.t.sol
@@ -32,21 +32,21 @@ contract AtmAuctionTest is DutchAuctionTest {
   }
 
   function test_fill_success_1() public override {
-    mintAndApprove(alice, defaultAmount * defaultStartPrice / 1e18, address(dutchAuction), address(usdcToken));
+    mintAndApprove(alice, defaultAmount * defaultStartPrice / (10**ethStrategy.decimals()), address(dutchAuction), address(usdcToken));
     super.test_fill_success_1();
 
     assertEq(usdcToken.balanceOf(alice), 0, "usdcToken balance not assigned correctly");
-    assertEq(usdcToken.balanceOf(address(governor)), defaultAmount * defaultStartPrice / 1e18, "usdcToken balance not assigned correctly");
+    assertEq(usdcToken.balanceOf(address(governor)), defaultAmount * defaultStartPrice / (10**ethStrategy.decimals()), "usdcToken balance not assigned correctly");
     assertEq(ethStrategy.balanceOf(alice), defaultAmount, "ethStrategy balance not assigned correctly");
   }
 
   function test_fill_success_2() public override {
     uint256 _amount = defaultAmount - 1;
-    mintAndApprove(alice, _amount * defaultStartPrice/1e18, address(dutchAuction), address(usdcToken));
+    mintAndApprove(alice, _amount * defaultStartPrice/(10**ethStrategy.decimals()), address(dutchAuction), address(usdcToken));
     super.test_fill_success_2();
 
     assertEq(usdcToken.balanceOf(alice), 0, "usdcToken balance not assigned correctly");
-    assertEq(usdcToken.balanceOf(address(governor)), _amount * defaultStartPrice / 1e18, "usdcToken balance not assigned correctly");
+    assertEq(usdcToken.balanceOf(address(governor)), _amount * defaultStartPrice / (10**ethStrategy.decimals()), "usdcToken balance not assigned correctly");
     assertEq(ethStrategy.balanceOf(alice), _amount, "ethStrategy balance not assigned correctly");
   }
 
@@ -71,7 +71,7 @@ contract AtmAuctionTest is DutchAuctionTest {
     vm.assume(delta_t <= type(uint128).max / delta_p);
 
     uint128 fillPrice = calculateFillPrice(_startTime, _duration, _startPrice, _endPrice, _elapsedTime);
-    uint256 mintAmount = _amount * fillPrice / 1e18;
+    uint256 mintAmount = _amount * fillPrice / (10**ethStrategy.decimals());
     mintAndApprove(alice, mintAmount, address(dutchAuction), address(usdcToken));
 
     fill(_amount, _startTime, _duration, _startPrice, _endPrice, _elapsedTime, _totalAmount);

--- a/test/BondAuction.t.sol
+++ b/test/BondAuction.t.sol
@@ -32,11 +32,11 @@ contract BondAuctionTest is DutchAuctionTest {
   }
 
   function test_fill_success_1() public override {
-    mintAndApprove(alice, defaultAmount * defaultStartPrice / 1e18, address(dutchAuction), address(usdcToken));
+    mintAndApprove(alice, defaultAmount * defaultStartPrice / (10**ethStrategy.decimals()), address(dutchAuction), address(usdcToken));
     super.test_fill_success_1();
 
     assertEq(usdcToken.balanceOf(alice), 0, "usdcToken balance not assigned correctly");
-    assertEq(usdcToken.balanceOf(address(dutchAuction)), defaultAmount * defaultStartPrice / 1e18, "usdcToken balance not assigned correctly");
+    assertEq(usdcToken.balanceOf(address(dutchAuction)), defaultAmount * defaultStartPrice / (10**ethStrategy.decimals()), "usdcToken balance not assigned correctly");
     BondAuction bondAuction = BondAuction(address(dutchAuction));
     (uint256 amount, uint256 price, uint256 startRedemption) = bondAuction.bonds(alice);
     assertEq(amount, defaultAmount, "amount not assigned correctly");
@@ -46,11 +46,11 @@ contract BondAuctionTest is DutchAuctionTest {
 
   function test_fill_success_2() public override {
     uint256 _amount = defaultAmount - 1;
-    mintAndApprove(alice, _amount * defaultStartPrice / 1e18, address(dutchAuction), address(usdcToken));
+    mintAndApprove(alice, _amount * defaultStartPrice / (10**ethStrategy.decimals()), address(dutchAuction), address(usdcToken));
     super.test_fill_success_2();
 
     assertEq(usdcToken.balanceOf(alice), 0, "usdcToken balance not assigned correctly");
-    assertEq(usdcToken.balanceOf(address(dutchAuction)), _amount * defaultStartPrice / 1e18, "usdcToken balance not assigned correctly");
+    assertEq(usdcToken.balanceOf(address(dutchAuction)), _amount * defaultStartPrice / (10**ethStrategy.decimals()), "usdcToken balance not assigned correctly");
     BondAuction bondAuction = BondAuction(address(dutchAuction));
     (uint256 amount, uint256 price, uint256 startRedemption) = bondAuction.bonds(alice);
     assertEq(amount, _amount, "amount not assigned correctly");
@@ -67,7 +67,7 @@ contract BondAuctionTest is DutchAuctionTest {
     assertEq(usdcToken.balanceOf(alice), 0, "usdcToken balance not assigned correctly");
     assertEq(ethStrategy.balanceOf(alice), defaultAmount, "ethStrategy balance not assigned correctly");
     assertEq(usdcToken.balanceOf(address(dutchAuction)), 0, "usdcToken balance not assigned correctly");
-    assertEq(usdcToken.balanceOf(address(governor)), defaultAmount * defaultStartPrice / 1e18, "usdcToken balance not assigned correctly");
+    assertEq(usdcToken.balanceOf(address(governor)), defaultAmount * defaultStartPrice / (10**ethStrategy.decimals()), "usdcToken balance not assigned correctly");
 
     (uint256 amount, uint256 price, uint256 startRedemption) = bondAuction.bonds(alice);
     assertEq(amount, 0, "amount not assigned correctly");
@@ -117,7 +117,7 @@ contract BondAuctionTest is DutchAuctionTest {
     vm.warp(block.timestamp + defaultDuration + 1);
     vm.prank(alice);
     bondAuction.withdraw();
-    assertEq(usdcToken.balanceOf(alice), defaultAmount * defaultStartPrice / 1e18, "usdcToken balance not assigned correctly");
+    assertEq(usdcToken.balanceOf(alice), defaultAmount * defaultStartPrice / (10**ethStrategy.decimals()), "usdcToken balance not assigned correctly");
     assertEq(usdcToken.balanceOf(address(dutchAuction)), 0, "usdcToken balance not assigned correctly");
     assertEq(ethStrategy.balanceOf(alice), 0, "ethStrategy balance not assigned correctly");
 
@@ -154,7 +154,7 @@ contract BondAuctionTest is DutchAuctionTest {
   function test_fill_unredeemedBond() public {
     uint64 expectedStartTime = uint64(block.timestamp);
     uint128 _amount = defaultAmount / 2;
-    mintAndApprove(alice, _amount * defaultStartPrice / 1e18, address(dutchAuction), address(usdcToken));
+    mintAndApprove(alice, _amount * defaultStartPrice / (10**ethStrategy.decimals()), address(dutchAuction), address(usdcToken));
     
     test_startAuction_success_1();
     vm.prank(alice);
@@ -172,7 +172,7 @@ contract BondAuctionTest is DutchAuctionTest {
     }
 
     assertEq(usdcToken.balanceOf(alice), 0, "usdcToken balance not assigned correctly");
-    assertEq(usdcToken.balanceOf(address(dutchAuction)), _amount * defaultStartPrice / 1e18, "usdcToken balance not assigned correctly");
+    assertEq(usdcToken.balanceOf(address(dutchAuction)), _amount * defaultStartPrice / (10**ethStrategy.decimals()), "usdcToken balance not assigned correctly");
     BondAuction bondAuction = BondAuction(address(dutchAuction));
 
     {
@@ -209,7 +209,7 @@ contract BondAuctionTest is DutchAuctionTest {
     vm.assume(delta_t <= type(uint128).max / delta_p);
 
     uint128 fillPrice = calculateFillPrice(_startTime, _duration, _startPrice, _endPrice, _elapsedTime);
-    uint256 mintAmount = _amount * fillPrice / 1e18;
+    uint256 mintAmount = _amount * fillPrice / (10**ethStrategy.decimals());
     mintAndApprove(alice, mintAmount, address(dutchAuction), address(usdcToken));
 
     fill(_amount, _startTime, _duration, _startPrice, _endPrice, _elapsedTime, _totalAmount);

--- a/test/BondAuction.t.sol
+++ b/test/BondAuction.t.sol
@@ -32,11 +32,11 @@ contract BondAuctionTest is DutchAuctionTest {
   }
 
   function test_fill_success_1() public override {
-    mintAndApprove(alice, defaultAmount * defaultStartPrice, address(dutchAuction), address(usdcToken));
+    mintAndApprove(alice, defaultAmount * defaultStartPrice / 1e18, address(dutchAuction), address(usdcToken));
     super.test_fill_success_1();
 
     assertEq(usdcToken.balanceOf(alice), 0, "usdcToken balance not assigned correctly");
-    assertEq(usdcToken.balanceOf(address(dutchAuction)), defaultAmount * defaultStartPrice, "usdcToken balance not assigned correctly");
+    assertEq(usdcToken.balanceOf(address(dutchAuction)), defaultAmount * defaultStartPrice / 1e18, "usdcToken balance not assigned correctly");
     BondAuction bondAuction = BondAuction(address(dutchAuction));
     (uint256 amount, uint256 price, uint256 startRedemption) = bondAuction.bonds(alice);
     assertEq(amount, defaultAmount, "amount not assigned correctly");
@@ -46,11 +46,11 @@ contract BondAuctionTest is DutchAuctionTest {
 
   function test_fill_success_2() public override {
     uint256 _amount = defaultAmount - 1;
-    mintAndApprove(alice, _amount * defaultStartPrice, address(dutchAuction), address(usdcToken));
+    mintAndApprove(alice, _amount * defaultStartPrice / 1e18, address(dutchAuction), address(usdcToken));
     super.test_fill_success_2();
 
     assertEq(usdcToken.balanceOf(alice), 0, "usdcToken balance not assigned correctly");
-    assertEq(usdcToken.balanceOf(address(dutchAuction)), _amount * defaultStartPrice, "usdcToken balance not assigned correctly");
+    assertEq(usdcToken.balanceOf(address(dutchAuction)), _amount * defaultStartPrice / 1e18, "usdcToken balance not assigned correctly");
     BondAuction bondAuction = BondAuction(address(dutchAuction));
     (uint256 amount, uint256 price, uint256 startRedemption) = bondAuction.bonds(alice);
     assertEq(amount, _amount, "amount not assigned correctly");
@@ -67,7 +67,7 @@ contract BondAuctionTest is DutchAuctionTest {
     assertEq(usdcToken.balanceOf(alice), 0, "usdcToken balance not assigned correctly");
     assertEq(ethStrategy.balanceOf(alice), defaultAmount, "ethStrategy balance not assigned correctly");
     assertEq(usdcToken.balanceOf(address(dutchAuction)), 0, "usdcToken balance not assigned correctly");
-    assertEq(usdcToken.balanceOf(address(governor)), defaultAmount * defaultStartPrice, "usdcToken balance not assigned correctly");
+    assertEq(usdcToken.balanceOf(address(governor)), defaultAmount * defaultStartPrice / 1e18, "usdcToken balance not assigned correctly");
 
     (uint256 amount, uint256 price, uint256 startRedemption) = bondAuction.bonds(alice);
     assertEq(amount, 0, "amount not assigned correctly");
@@ -117,7 +117,7 @@ contract BondAuctionTest is DutchAuctionTest {
     vm.warp(block.timestamp + defaultDuration + 1);
     vm.prank(alice);
     bondAuction.withdraw();
-    assertEq(usdcToken.balanceOf(alice), defaultAmount * defaultStartPrice, "usdcToken balance not assigned correctly");
+    assertEq(usdcToken.balanceOf(alice), defaultAmount * defaultStartPrice / 1e18, "usdcToken balance not assigned correctly");
     assertEq(usdcToken.balanceOf(address(dutchAuction)), 0, "usdcToken balance not assigned correctly");
     assertEq(ethStrategy.balanceOf(alice), 0, "ethStrategy balance not assigned correctly");
 
@@ -154,7 +154,7 @@ contract BondAuctionTest is DutchAuctionTest {
   function test_fill_unredeemedBond() public {
     uint64 expectedStartTime = uint64(block.timestamp);
     uint128 _amount = defaultAmount / 2;
-    mintAndApprove(alice, _amount * defaultStartPrice, address(dutchAuction), address(usdcToken));
+    mintAndApprove(alice, _amount * defaultStartPrice / 1e18, address(dutchAuction), address(usdcToken));
     
     test_startAuction_success_1();
     vm.prank(alice);
@@ -172,7 +172,7 @@ contract BondAuctionTest is DutchAuctionTest {
     }
 
     assertEq(usdcToken.balanceOf(alice), 0, "usdcToken balance not assigned correctly");
-    assertEq(usdcToken.balanceOf(address(dutchAuction)), _amount * defaultStartPrice, "usdcToken balance not assigned correctly");
+    assertEq(usdcToken.balanceOf(address(dutchAuction)), _amount * defaultStartPrice / 1e18, "usdcToken balance not assigned correctly");
     BondAuction bondAuction = BondAuction(address(dutchAuction));
 
     {
@@ -209,7 +209,7 @@ contract BondAuctionTest is DutchAuctionTest {
     vm.assume(delta_t <= type(uint128).max / delta_p);
 
     uint128 fillPrice = calculateFillPrice(_startTime, _duration, _startPrice, _endPrice, _elapsedTime);
-    uint256 mintAmount = _amount * fillPrice;
+    uint256 mintAmount = _amount * fillPrice / 1e18;
     mintAndApprove(alice, mintAmount, address(dutchAuction), address(usdcToken));
 
     fill(_amount, _startTime, _duration, _startPrice, _endPrice, _elapsedTime, _totalAmount);


### PR DESCRIPTION
Fixes scaling of auction quantities

Asuming prices are in USDC decimals (6) and amounts are in ETHSR decimals (18), USDC amounts transferred in auction need to be scaled down by 1e18 to have the correct amount be transferred. 

```usdcAmount = ethsrAmount * usdcPrice```

to

```usdcAmount = ethsrAmount * usdcPrice / 1e18```

Fixes #6 